### PR TITLE
task-2: added utility functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module ova-conversation-api
+
+go 1.16

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,51 @@
+package utils
+
+import "errors"
+
+func MakeSliceOfSlices(source []int, num int) ([][]int, error) {
+	if num <= 0 {
+		return nil, errors.New("invalid value of the num parameter")
+	}
+
+	result := make([][]int, 0, len(source)/num+1)
+	prev := 0
+
+	for prev+num < len(source) {
+		result = append(result, source[prev:prev+num])
+		prev += num
+	}
+	result = append(result, source[prev:])
+
+	return result, nil
+}
+
+func ReplaceKeyValue(source map[int]string) (map[string]int, error) {
+	result := make(map[string]int)
+
+	for key, value := range source {
+		if _, ok := result[value]; ok {
+			return nil, errors.New("same keys in the result map")
+		}
+		result[value] = key
+	}
+
+	return result, nil
+}
+
+func FilterSlice(source []int, filter []int) []int {
+	filterSet := make(map[int]int)
+
+	for _, value := range filter {
+		filterSet[value] = 0
+	}
+
+	result := make([]int, 0)
+
+	for _, value := range source {
+		if _, ok := filterSet[value]; !ok {
+			result = append(result, value)
+		}
+	}
+
+	return result
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,70 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMakeSliceOfSlices(t *testing.T) {
+	type testType struct {
+		source []int
+		num    int
+		result [][]int
+	}
+
+	var tests = []testType{
+		{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 4, [][]int{{1, 2, 3, 4}, {5, 6, 7, 8}, {9, 10}}},
+		{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 2, [][]int{{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}}},
+		{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 10, [][]int{{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}}},
+		{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 100, [][]int{{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}}},
+	}
+
+	for _, value := range tests {
+		actual, _ := MakeSliceOfSlices(value.source, value.num)
+		if !reflect.DeepEqual(value.result, actual) {
+			t.Errorf("Expected: %v, actual: %v", value.result, actual)
+		}
+	}
+}
+
+func TestReplaceKeyValue(t *testing.T) {
+	type testType struct {
+		source map[int]string
+		result map[string]int
+	}
+
+	var tests = []testType{
+		{map[int]string{1: "one", 2: "two", 3: "three"}, map[string]int{"one": 1, "two": 2, "three": 3}},
+		{map[int]string{1: "one", 2: "two", 3: "two"}, nil},
+	}
+
+	for _, value := range tests {
+		actual, _ := ReplaceKeyValue(value.source)
+		if !reflect.DeepEqual(value.result, actual) {
+			t.Errorf("Expected: %v, actual: %v", value.result, actual)
+		}
+	}
+}
+
+func TestFilterSlice(t *testing.T) {
+	type testType struct {
+		source []int
+		filter []int
+		result []int
+	}
+
+	var tests = []testType{
+		{[]int{1, 2, 3, 4, 5}, []int{2, 4}, []int{1, 3, 5}},
+		{[]int{1, 2, 3, 4, 5}, []int{}, []int{1, 2, 3, 4, 5}},
+		{[]int{1, 2, 3, 4, 5}, []int{1, 2, 3, 4, 5}, []int{}},
+		{[]int{1, 2, 3, 4, 5}, []int{6, 7}, []int{1, 2, 3, 4, 5}},
+		{[]int{1, 1, 1}, []int{1}, []int{}},
+	}
+
+	for _, value := range tests {
+		actual := FilterSlice(value.source, value.filter)
+		if !reflect.DeepEqual(value.result, actual) {
+			t.Errorf("Expected: %v, actual: %v", value.result, actual)
+		}
+	}
+}


### PR DESCRIPTION
Задание II
В пакете internal/utils вашего репозитория нужно реализовать экспортируемые функции для

- Разделение на слайса на батчи - исходный слайс конвертировать в слайс слайсов - чанки одинкового размера (кроме последнего)

- Обратный ключ - происходит конвертация отображения (“ключ-значение“) в отображение (“значение-ключ“)

- Фильтрация по захордкоженному списку - нужно отфильтровать входной слайс по критерию отсутствия элемента в захардкоженном списке

В качестве типов сейчас будем использовать встроенные типы: целые числа или строковые