### PR TITLE
task-5: add interface Saver

### DIFF
--- a/internal/domain/conversation_test.go
+++ b/internal/domain/conversation_test.go
@@ -2,9 +2,10 @@ package domain
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestConversation_String(t *testing.T) {

--- a/internal/flusher/flusher.go
+++ b/internal/flusher/flusher.go
@@ -2,6 +2,7 @@ package flusher
 
 import (
 	"log"
+
 	"ova-conversation-api/internal/domain"
 	"ova-conversation-api/internal/repo"
 	"ova-conversation-api/internal/utils"

--- a/internal/flusher/flusher_test.go
+++ b/internal/flusher/flusher_test.go
@@ -2,12 +2,14 @@ package flusher
 
 import (
 	"errors"
+	"time"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"ova-conversation-api/internal/domain"
 	"ova-conversation-api/internal/repo"
-	"time"
 )
 
 var _ = Describe("Flusher", func() {

--- a/internal/saver/saver.go
+++ b/internal/saver/saver.go
@@ -1,0 +1,96 @@
+package saver
+
+import (
+	"log"
+	"ova-conversation-api/internal/domain"
+	"ova-conversation-api/internal/flusher"
+	"sync"
+	"time"
+)
+
+type Saver interface {
+	Init()
+	Save(entity domain.Conversation)
+	Close()
+}
+
+type saver struct {
+	mux        sync.Mutex
+	chanTicker chan struct{}
+	duration   uint
+	capacity   uint
+	flusher    flusher.Flusher
+	data       []domain.Conversation
+}
+
+func NewSaver(duration uint, capacity uint, flusher flusher.Flusher) Saver {
+	return &saver{
+		duration: duration,
+		capacity: capacity,
+		flusher:  flusher,
+		data:     make([]domain.Conversation, 0, capacity),
+	}
+}
+
+func (s *saver) Init() {
+	ticker := time.NewTicker(time.Duration(s.duration) * time.Millisecond)
+	s.chanTicker = make(chan struct{})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case _, ok := <-s.chanTicker:
+				if !ok {
+					ticker.Stop()
+
+					return
+				}
+			case <-ticker.C:
+				s.flush()
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+func (s *saver) Save(entity domain.Conversation) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	if (cap(s.data) == 0) || (len(s.data) == cap(s.data)-1) {
+		s.data = append(s.data, entity)
+		s.flush()
+	}
+
+	s.data = append(s.data, entity)
+}
+
+func (s *saver) Close() {
+	s.flush()
+
+	close(s.chanTicker)
+}
+
+func (s *saver) flush() {
+	if len(s.data) == 0 {
+		return
+	}
+
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	notFlushed := s.flusher.Flush(s.data)
+	if len(notFlushed) > 0 {
+		s.data = make([]domain.Conversation, len(notFlushed), s.capacity)
+		copy(s.data, notFlushed)
+		log.Printf("saver did not flush the amount of data: %d %T", len(notFlushed), s.data)
+	} else {
+		s.data = make([]domain.Conversation, 0, s.capacity)
+	}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+
 	"ova-conversation-api/internal/domain"
 )
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,11 +1,13 @@
 package utils
 
 import (
-	"github.com/stretchr/testify/require"
-	"ova-conversation-api/internal/domain"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"ova-conversation-api/internal/domain"
 )
 
 func TestMakeSliceOfSlices(t *testing.T) {


### PR DESCRIPTION
Задание V:
Нужно в пакете saver имплементировать Saver интерфейс, с возможностью писать в хранилище данные, через Flusher, сброс данных происходит во flusher по определенному таймауту или при вызове метода Close
package saver

```
type Saver interface {
	Save(entity models.Entity) // заменить на свою сущность
    // Init()
	Close()
}
```

```
// NewSaver возвращает Saver с поддержкой переодического сохранения
func NewSaver(
	capacity uint,
	flusher flusher.Flusher,
  // ...
) Saver {
  // ...
}
```
До сброса в хранилище, данные хранятся в slice. который принадлежит saver-у.
Установка capacity данного slice-a идет на этапе конструирование -  при вызове NewSaver